### PR TITLE
Fix sizing for text in info.ejs

### DIFF
--- a/views/info.ejs
+++ b/views/info.ejs
@@ -34,9 +34,9 @@
         <thead>
           <tr>
             <th>Shortened URL:</th>
-            <th>
+            <td>
               <a href="/<%= shortUrl %>">https://qurl.gq/<%= shortUrl %></a>
-            </th>
+            </td>
           </tr>
         </thead>
         <tbody>


### PR DESCRIPTION
Fix sizing for text

<img width="257" alt="image" src="https://user-images.githubusercontent.com/97064249/194603750-b8f50003-7655-4c19-9a70-b43b6f54c360.png">
