### PR TITLE
hide 'log ips' from front end

### DIFF
--- a/views/index.ejs
+++ b/views/index.ejs
@@ -42,10 +42,12 @@
               Custom Short URL (Optional):
               <input placeholder="" type="text" name="customURL" />
             </label>
+             <!-- 
             <label for="logIps">
               <input type="checkbox" name="logIps" id="logIps" />
               Collect IP Addresses
             </label>
+            -->
           </details>
         </fieldset>
         <button type="submit" name="submitButton">


### PR DESCRIPTION
hide 'log ips' from front end until IP logging is fixed